### PR TITLE
added suport for '-O --open' to 'mite create'

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -5,5 +5,13 @@
 	"diff": {
 		"cmd": "diff",
 		"args": ["-C", "5", "{proper}", "{current}"]
+	},
+	"open": {
+		"osx": {
+			"cmd": "open",
+			"args": ["{path}"]
+		},
+		"windows": {},
+		"linux": {}
 	}
 }

--- a/lib/cli/create.js
+++ b/lib/cli/create.js
@@ -1,11 +1,17 @@
 var path = require("path"),
 	fs = require("fs"),
 	reporter = require("./reporter"),
-	q = require("q");
+	q = require("q"),
+	_ = require("underscore"),
+	exec = require("child_process").exec;
 
 module.exports = CreateCommand;
 
-function CreateCommand(){}
+function CreateCommand(opts){
+	this.options = _.extend({
+		open: false
+	}, opts);
+}
 
 CreateCommand.prototype.preExecute = function(config) {
 	return config;
@@ -14,13 +20,32 @@ CreateCommand.prototype.preExecute = function(config) {
 CreateCommand.prototype.execute = function(config) {
 	var def = q.defer(),
 		isoString = (new Date()).toISOString(),
-		filename = (isoString.substring(0, isoString.lastIndexOf(".")) + "Z").replace(/\:/g, "-") + ".sql";
+		filename = (isoString.substring(0, isoString.lastIndexOf(".")) + "Z").replace(/\:/g, "-") + ".sql",
+		filePath = path.join(config.migrationRoot, filename);
 
 	try {
-		fs.writeFileSync(path.join(config.migrationRoot, filename), require("../../templates/migration.sql"));
+		fs.writeFileSync(filePath, require("../../templates/migration.sql"));
 		reporter.success("migration created: " + filename);
 	} catch (e) {
 		reporter.err(e.toString());
+	}
+
+	if(this.options.open) {
+		var open = config.open[config.platform];
+		if(!open || !open.cmd) {
+			reporter.warn("no 'open' command for platform '%s' defined", config.platform);
+		} else {
+			var cmd = [open.cmd].concat(open.args.map(function(arg) {
+				if(arg === "{path}") {
+					return filePath;
+				} else return arg;
+			}));
+
+			exec(cmd.join(" "), {
+				stdout: process.stdout,
+				stdin: process.stdin
+			});
+		}
 	}
 
 	def.resolve();

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -4,6 +4,7 @@ require("../requireExtensions");
 
 var program = require("commander"),
 	path = require("path"),
+	os = require("os"),
 	reporter = require("./reporter"),
 	fs = require("fs"),
 	q = require("q"),
@@ -81,11 +82,14 @@ var stepDownCli = program
 	});
 
 
-program
+var createCli = program
 	.command("create")
+	.option("-O --open", "open the new migration after creating it")
 	.description("create a new (empty) migration file")
 	.action(function() {
-		runCommand(new CreateCommand());
+		runCommand(new CreateCommand({
+			open: createCli.open
+		}));
 	});
 
 program
@@ -96,6 +100,8 @@ program
 			downCli.help();
 		} else if(arg === "stepdown") {
 			stepDownCli.help();
+		} else if(arg === "create") {
+			createCli.help();
 		} else {
 			program.help();
 		}
@@ -161,6 +167,21 @@ function getMiteConfig(root) {
 	var cfg = _.extend({}, defaults, userConfig);
 	cfg.migrationRoot = path.join(root, cfg.migrationFolderName);
 	cfg.miteRoot = root;
+
+	var platform = os.type().toLowerCase();
+	switch(platform) {
+		case "darwin":
+			platform = "osx";
+			break;
+		case "windows_nt":
+			platform = "windows";
+			break;
+		default:
+			break;
+	}
+	cfg.platform = platform;
+
+
 	def.resolve(cfg);
 
 	return def.promise;


### PR DESCRIPTION
only supports osx out of the box right now. Windows support should be easy. linux support will be a bit worse since the necessary functionality is desktop-environment specific (maybe we should add a bash script  that attempts to be cross-linux-platform compatible?)
